### PR TITLE
fix(mcp): return resource/prompt results from transports; add StreamManager.get_prompt

### DIFF
--- a/src/chuk_tool_processor/mcp/stream_manager.py
+++ b/src/chuk_tool_processor/mcp/stream_manager.py
@@ -720,6 +720,53 @@ class StreamManager:
                 logger.debug("resources/read failed for %s: %s", name, exc)
         return {}
 
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        server_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a specific prompt by name.
+
+        Args:
+            name: Prompt name to fetch.
+            arguments: Optional arguments used to render the prompt template.
+            server_name: Optional server name to target. If None, tries all.
+
+        Returns:
+            Prompt result dict from the server, or empty dict on error.
+        """
+        if self._closed:
+            return {}
+
+        # If a specific server is requested, try just that one
+        if server_name and server_name in self.transports:
+            transport = self.transports[server_name]
+            if hasattr(transport, "get_prompt"):
+                try:
+                    return await asyncio.wait_for(
+                        transport.get_prompt(name, arguments),
+                        timeout=self.timeout_config.operation,
+                    )
+                except Exception as exc:
+                    logger.debug("prompts/get failed for %s: %s", server_name, exc)
+                    return {}
+
+        # Try all transports until one succeeds
+        for tname, transport in self.transports.items():
+            if not hasattr(transport, "get_prompt"):
+                continue
+            try:
+                result = await asyncio.wait_for(
+                    transport.get_prompt(name, arguments),
+                    timeout=self.timeout_config.operation,
+                )
+                if result:
+                    return result
+            except Exception as exc:
+                logger.debug("prompts/get failed for %s: %s", tname, exc)
+        return {}
+
     async def list_prompts(self) -> list[dict[str, Any]]:
         if self._closed:
             return []

--- a/src/chuk_tool_processor/mcp/transport/base_transport.py
+++ b/src/chuk_tool_processor/mcp/transport/base_transport.py
@@ -120,6 +120,19 @@ class MCPBaseTransport(ABC):
         """
         raise NotImplementedError
 
+    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Get a specific prompt by name.
+
+        Args:
+            name: Prompt name to fetch.
+            arguments: Optional arguments used to render the prompt template.
+
+        Returns:
+            Dictionary containing the prompt result or empty dict if not supported.
+        """
+        raise NotImplementedError
+
     # ------------------------------------------------------------------ #
     #  Metrics and monitoring (all transports should support these)     #
     # ------------------------------------------------------------------ #

--- a/src/chuk_tool_processor/mcp/transport/http_streamable_transport.py
+++ b/src/chuk_tool_processor/mcp/transport/http_streamable_transport.py
@@ -545,7 +545,12 @@ class HTTPStreamableTransport(MCPBaseTransport):
             response = await asyncio.wait_for(
                 send_resources_list(self._read_stream, self._write_stream), timeout=self.default_timeout
             )
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("List resources timed out")
             self._consecutive_failures += 1
@@ -564,7 +569,12 @@ class HTTPStreamableTransport(MCPBaseTransport):
             response = await asyncio.wait_for(
                 send_prompts_list(self._read_stream, self._write_stream), timeout=self.default_timeout
             )
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("List prompts timed out")
             self._consecutive_failures += 1
@@ -608,7 +618,12 @@ class HTTPStreamableTransport(MCPBaseTransport):
                 send_prompts_get(self._read_stream, self._write_stream, name, arguments or {}),
                 timeout=self.default_timeout,
             )
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("Get prompt timed out")
             self._consecutive_failures += 1

--- a/src/chuk_tool_processor/mcp/transport/stdio_transport.py
+++ b/src/chuk_tool_processor/mcp/transport/stdio_transport.py
@@ -601,7 +601,12 @@ class StdioTransport(MCPBaseTransport):
         try:
             response = await asyncio.wait_for(send_resources_list(*self._streams), timeout=self.default_timeout)
             self._consecutive_failures = 0  # Reset on success
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("List resources timed out")
             self._consecutive_failures += 1
@@ -618,7 +623,12 @@ class StdioTransport(MCPBaseTransport):
         try:
             response = await asyncio.wait_for(send_prompts_list(*self._streams), timeout=self.default_timeout)
             self._consecutive_failures = 0  # Reset on success
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("List prompts timed out")
             self._consecutive_failures += 1
@@ -659,7 +669,12 @@ class StdioTransport(MCPBaseTransport):
                 send_prompts_get(*self._streams, name, arguments or {}), timeout=self.default_timeout
             )
             self._consecutive_failures = 0  # Reset on success
-            return response if isinstance(response, dict) else {}
+            if isinstance(response, dict):
+                return response
+            # send_* helpers return a pydantic *Result model; normalize to a dict
+            if hasattr(response, "model_dump"):
+                return response.model_dump()
+            return {}
         except TimeoutError:
             logger.error("Get prompt timed out")
             self._consecutive_failures += 1

--- a/tests/mcp/test_stream_manager.py
+++ b/tests/mcp/test_stream_manager.py
@@ -1006,6 +1006,50 @@ class TestStreamManager:
 
         assert prompts == []
 
+    @pytest.mark.asyncio
+    async def test_get_prompt(self, stream_manager, mock_transport):
+        """get_prompt returns the prompt result from the transport."""
+        stream_manager.transports["server1"] = mock_transport
+        mock_transport.get_prompt = AsyncMock(
+            return_value={"messages": [{"role": "user", "content": {"type": "text", "text": "hi"}}]}
+        )
+
+        result = await stream_manager.get_prompt("greet", {"who": "world"})
+
+        assert result["messages"][0]["role"] == "user"
+        mock_transport.get_prompt.assert_awaited_once_with("greet", {"who": "world"})
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_specific_server(self, stream_manager, mock_transport):
+        """get_prompt targets a named server and skips the others."""
+        other = AsyncMock(spec=MCPBaseTransport)
+        other.get_prompt = AsyncMock(return_value={"messages": []})
+        stream_manager.transports["s1"] = other
+        stream_manager.transports["s2"] = mock_transport
+        mock_transport.get_prompt = AsyncMock(return_value={"messages": [{"role": "assistant", "content": {}}]})
+
+        result = await stream_manager.get_prompt("p", server_name="s2")
+
+        assert result["messages"][0]["role"] == "assistant"
+        mock_transport.get_prompt.assert_awaited_once()
+        other.get_prompt.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_when_closed(self, stream_manager):
+        """get_prompt returns empty when the manager is closed."""
+        await stream_manager.close()
+
+        assert await stream_manager.get_prompt("p") == {}
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_exception(self, stream_manager):
+        """get_prompt swallows transport errors and returns {}."""
+        tr = AsyncMock(spec=MCPBaseTransport)
+        tr.get_prompt = AsyncMock(side_effect=Exception("Failed"))
+        stream_manager.transports["s"] = tr
+
+        assert await stream_manager.get_prompt("p") == {}
+
     # ------------------------------------------------------------------ #
     # call_tool method with timeout tests                               #
     # ------------------------------------------------------------------ #

--- a/tests/mcp/transport/test_transport_pydantic_result_normalization.py
+++ b/tests/mcp/transport/test_transport_pydantic_result_normalization.py
@@ -1,0 +1,136 @@
+"""
+Regression tests: stream-based MCP transports must normalize the pydantic
+``*Result`` models returned by chuk_mcp's ``send_*`` helpers into plain dicts.
+
+Bug history
+-----------
+``list_resources`` / ``list_prompts`` / ``get_prompt`` on both the stdio and
+HTTP-streamable transports used::
+
+    return response if isinstance(response, dict) else {}
+
+``send_resources_list`` / ``send_prompts_list`` / ``send_prompts_get`` return
+pydantic models (``ListResourcesResult`` etc.), *not* dicts, so the
+``isinstance(..., dict)`` guard silently discarded every result and the methods
+returned ``{}``. ``read_resource`` already handled this correctly via
+``model_dump()``.
+
+The pre-existing tests masked the bug because they mocked the ``send_*`` helpers
+with plain dicts (which trivially satisfy the ``isinstance`` check) rather than
+with the pydantic models the real helpers return. These tests use the real
+chuk_mcp models so they reflect production behaviour, and run against both
+transports.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from chuk_mcp.protocol.messages.prompts.prompt import Prompt, PromptMessage
+from chuk_mcp.protocol.messages.prompts.send_messages import (
+    GetPromptResult,
+    ListPromptsResult,
+)
+from chuk_mcp.protocol.messages.resources.resource import Resource
+from chuk_mcp.protocol.messages.resources.resource_content import ResourceContent
+from chuk_mcp.protocol.messages.resources.send_messages import (
+    ListResourcesResult,
+    ReadResourceResult,
+)
+
+from chuk_tool_processor.mcp.transport.http_streamable_transport import (
+    HTTPStreamableTransport,
+)
+from chuk_tool_processor.mcp.transport.stdio_transport import StdioTransport
+
+STDIO_MOD = "chuk_tool_processor.mcp.transport.stdio_transport"
+HTTP_MOD = "chuk_tool_processor.mcp.transport.http_streamable_transport"
+
+
+def _make_stdio() -> StdioTransport:
+    t = StdioTransport({"command": "python", "args": ["-m", "x"]})
+    t._initialized = True
+    t._streams = (Mock(), Mock())
+    return t
+
+
+def _make_http() -> HTTPStreamableTransport:
+    t = HTTPStreamableTransport("http://test.com")
+    t._initialized = True
+    t._read_stream = Mock()
+    t._write_stream = Mock()
+    return t
+
+
+# (transport factory, module to patch send_* in)
+TRANSPORTS = [
+    pytest.param(_make_stdio, STDIO_MOD, id="stdio"),
+    pytest.param(_make_http, HTTP_MOD, id="http"),
+]
+
+
+class TestPydanticResultNormalization:
+    """Every list/get transport method must dump pydantic results to dicts."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_list_resources_normalizes_model(self, factory, mod):
+        transport = factory()
+        model = ListResourcesResult(resources=[Resource(uri="demo://r1", name="r1")])
+        with patch(f"{mod}.send_resources_list", AsyncMock(return_value=model)):
+            result = await transport.list_resources()
+        assert isinstance(result, dict)
+        assert result == model.model_dump()
+        assert result["resources"][0]["uri"] == "demo://r1"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_list_prompts_normalizes_model(self, factory, mod):
+        transport = factory()
+        model = ListPromptsResult(prompts=[Prompt(name="greet")])
+        with patch(f"{mod}.send_prompts_list", AsyncMock(return_value=model)):
+            result = await transport.list_prompts()
+        assert isinstance(result, dict)
+        assert result == model.model_dump()
+        assert result["prompts"][0]["name"] == "greet"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_get_prompt_normalizes_model(self, factory, mod):
+        transport = factory()
+        model = GetPromptResult(messages=[PromptMessage(role="user", content={"type": "text", "text": "hi"})])
+        with patch(f"{mod}.send_prompts_get", AsyncMock(return_value=model)):
+            result = await transport.get_prompt("greet", {})
+        assert isinstance(result, dict)
+        assert result == model.model_dump()
+        assert result["messages"][0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_read_resource_still_normalizes_model(self, factory, mod):
+        # read_resource already handled models; guard against regressions.
+        transport = factory()
+        model = ReadResourceResult(contents=[ResourceContent(uri="demo://r1", text="hello")])
+        with patch(f"{mod}.send_resources_read", AsyncMock(return_value=model)):
+            result = await transport.read_resource("demo://r1")
+        assert isinstance(result, dict)
+        assert result == model.model_dump()
+        assert result["contents"][0]["text"] == "hello"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_dict_response_passes_through(self, factory, mod):
+        # Helpers/servers that already yield a dict must keep working unchanged.
+        transport = factory()
+        payload = {"resources": [{"uri": "demo://r1", "name": "r1"}]}
+        with patch(f"{mod}.send_resources_list", AsyncMock(return_value=payload)):
+            result = await transport.list_resources()
+        assert result == payload
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("factory, mod", TRANSPORTS)
+    async def test_non_model_non_dict_is_safe(self, factory, mod):
+        # An unexpected response type must degrade to {} rather than raise.
+        transport = factory()
+        with patch(f"{mod}.send_prompts_list", AsyncMock(return_value=None)):
+            result = await transport.list_prompts()
+        assert result == {}


### PR DESCRIPTION
## Summary
Two related fixes to the MCP resource/prompt plumbing in the transports and `StreamManager`:

1. **Transports silently drop `list_resources` / `list_prompts` / `get_prompt` results.**
2. **`StreamManager` has no `get_prompt`**, so a single prompt can't be fetched through the
   manager-level API even though every transport implements it.

## 1. Transports discard pydantic results (bug)
`list_resources`, `list_prompts`, and `get_prompt` on the stdio and HTTP-streamable
transports normalize with:

```python
return response if isinstance(response, dict) else {}
```

But the `chuk_mcp` helpers they call return **pydantic models**, not dicts
(`ListResourcesResult`, `ListPromptsResult`, `GetPromptResult`). A model isn't a `dict`,
so the guard fails and the result is silently discarded → `{}`. `read_resource` in the same
files already handles this correctly via a `model_dump()` fallback.

**Fix:** apply that existing `read_resource` pattern to `list_resources`, `list_prompts`,
and `get_prompt` (6 call sites, 2 files). SSE is unaffected — it parses raw dict responses
via `_send_request`.

Why existing tests missed it: the transport tests mocked the `send_*` helpers with plain
**dicts**, which trivially satisfy the discarded `isinstance(..., dict)` check. The added
regression tests use the **real** `chuk_mcp` result models.

## 2. Add `StreamManager.get_prompt` (+ base-transport method)
`StreamManager` exposes `list_resources` / `read_resource` / `list_prompts` but not
`get_prompt`. Add `StreamManager.get_prompt(name, arguments=None, server_name=None)`,
mirroring `read_resource` (specific-server targeting, else try each transport), and declare
`get_prompt` on `MCPBaseTransport` so the abstract interface matches the transports that
already implement it.

## Tests
- New `tests/mcp/transport/test_transport_pydantic_result_normalization.py` (both
  transports): list/get methods return the model's `model_dump()`; `read_resource`
  regression; dict pass-through; non-model/non-dict → `{}`. On the unpatched source the
  model cases fail at exactly the 6 buggy sites; with the fix all pass.
- `StreamManager.get_prompt`: success, specific-server targeting, closed → `{}`, error → `{}`.
- Full transport + stream-manager + base-transport suites green (380 + 122).
