### PR TITLE
feat(mcp): add StreamManager.get_prompt (+ base-transport method)

### DIFF
--- a/src/chuk_tool_processor/mcp/stream_manager.py
+++ b/src/chuk_tool_processor/mcp/stream_manager.py
@@ -720,6 +720,53 @@ class StreamManager:
                 logger.debug("resources/read failed for %s: %s", name, exc)
         return {}
 
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        server_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a specific prompt by name.
+
+        Args:
+            name: Prompt name to fetch.
+            arguments: Optional arguments used to render the prompt template.
+            server_name: Optional server name to target. If None, tries all.
+
+        Returns:
+            Prompt result dict from the server, or empty dict on error.
+        """
+        if self._closed:
+            return {}
+
+        # If a specific server is requested, try just that one
+        if server_name and server_name in self.transports:
+            transport = self.transports[server_name]
+            if hasattr(transport, "get_prompt"):
+                try:
+                    return await asyncio.wait_for(
+                        transport.get_prompt(name, arguments),
+                        timeout=self.timeout_config.operation,
+                    )
+                except Exception as exc:
+                    logger.debug("prompts/get failed for %s: %s", server_name, exc)
+                    return {}
+
+        # Try all transports until one succeeds
+        for tname, transport in self.transports.items():
+            if not hasattr(transport, "get_prompt"):
+                continue
+            try:
+                result = await asyncio.wait_for(
+                    transport.get_prompt(name, arguments),
+                    timeout=self.timeout_config.operation,
+                )
+                if result:
+                    return result
+            except Exception as exc:
+                logger.debug("prompts/get failed for %s: %s", tname, exc)
+        return {}
+
     async def list_prompts(self) -> list[dict[str, Any]]:
         if self._closed:
             return []

--- a/src/chuk_tool_processor/mcp/transport/base_transport.py
+++ b/src/chuk_tool_processor/mcp/transport/base_transport.py
@@ -120,6 +120,19 @@ class MCPBaseTransport(ABC):
         """
         raise NotImplementedError
 
+    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Get a specific prompt by name.
+
+        Args:
+            name: Prompt name to fetch.
+            arguments: Optional arguments used to render the prompt template.
+
+        Returns:
+            Dictionary containing the prompt result or empty dict if not supported.
+        """
+        raise NotImplementedError
+
     # ------------------------------------------------------------------ #
     #  Metrics and monitoring (all transports should support these)     #
     # ------------------------------------------------------------------ #

--- a/tests/mcp/test_stream_manager.py
+++ b/tests/mcp/test_stream_manager.py
@@ -1006,6 +1006,50 @@ class TestStreamManager:
 
         assert prompts == []
 
+    @pytest.mark.asyncio
+    async def test_get_prompt(self, stream_manager, mock_transport):
+        """get_prompt returns the prompt result from the transport."""
+        stream_manager.transports["server1"] = mock_transport
+        mock_transport.get_prompt = AsyncMock(
+            return_value={"messages": [{"role": "user", "content": {"type": "text", "text": "hi"}}]}
+        )
+
+        result = await stream_manager.get_prompt("greet", {"who": "world"})
+
+        assert result["messages"][0]["role"] == "user"
+        mock_transport.get_prompt.assert_awaited_once_with("greet", {"who": "world"})
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_specific_server(self, stream_manager, mock_transport):
+        """get_prompt targets a named server and skips the others."""
+        other = AsyncMock(spec=MCPBaseTransport)
+        other.get_prompt = AsyncMock(return_value={"messages": []})
+        stream_manager.transports["s1"] = other
+        stream_manager.transports["s2"] = mock_transport
+        mock_transport.get_prompt = AsyncMock(return_value={"messages": [{"role": "assistant", "content": {}}]})
+
+        result = await stream_manager.get_prompt("p", server_name="s2")
+
+        assert result["messages"][0]["role"] == "assistant"
+        mock_transport.get_prompt.assert_awaited_once()
+        other.get_prompt.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_when_closed(self, stream_manager):
+        """get_prompt returns empty when the manager is closed."""
+        await stream_manager.close()
+
+        assert await stream_manager.get_prompt("p") == {}
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_exception(self, stream_manager):
+        """get_prompt swallows transport errors and returns {}."""
+        tr = AsyncMock(spec=MCPBaseTransport)
+        tr.get_prompt = AsyncMock(side_effect=Exception("Failed"))
+        stream_manager.transports["s"] = tr
+
+        assert await stream_manager.get_prompt("p") == {}
+
     # ------------------------------------------------------------------ #
     # call_tool method with timeout tests                               #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
`StreamManager` exposes `list_resources`, `read_resource`, and `list_prompts`, but **not
`get_prompt`** — even though every concrete transport (stdio / HTTP / SSE) implements
`get_prompt`. So there is currently no way to fetch a single prompt through the
manager-level API.

## Change
- Add `StreamManager.get_prompt(name, arguments=None, server_name=None)`, mirroring the
  existing `read_resource`: target a specific server when given, otherwise try each
  transport until one returns a result; return `{}` when closed or on error.
- Declare `get_prompt` on `MCPBaseTransport` so the abstract interface matches the
  transports that already implement it (a non-abstract default raising
  `NotImplementedError`, exactly like `read_resource`).

## Tests
`StreamManager.get_prompt`: success, specific-server targeting (other servers skipped),
closed manager → `{}`, transport error → `{}`. Full `test_stream_manager.py` +
`test_base_transport.py`: **122 passed**.

## Note
This adds the manager-level method. The transports' own `get_prompt` result handling
(it discarded the pydantic `GetPromptResult`) is fixed in #45; the two together let
callers fetch a prompt end-to-end.
