### PR TITLE
deps: cap chuk-mcp below 0.10 (short-term, pure-Python)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.26.1]
+
+### Changed
+
+- **Cap `chuk-mcp` below 0.10.** The 0.10 line is the Rust-backed `chuk-mcp` that
+  depends on `chuk-mcp-rs`, which is not yet published to PyPI. Without this cap a
+  `chuk-mcp` 0.10 release would be auto-resolved by `chuk-mcp>=0.9` and break
+  installs (and, transitively, consumers such as `mcp-cli`). The upper bound still
+  allows 0.9.x patch/security releases; it will be lifted once `chuk-mcp-rs` (and
+  `chuk-mcp` 0.10) are published and validated.
+
 ## [0.26.0]
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "chuk-mcp>=0.9",
+    # Cap below 0.10: the 0.10 line is the Rust-backed chuk-mcp that depends on
+    # chuk-mcp-rs, which is not published yet. Lift once chuk-mcp-rs is on PyPI.
+    "chuk-mcp>=0.9,<0.10",
     "python-dotenv>=1.0.0",
     "psutil>=7.0.0",
     "pydantic>=2.11.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chuk-tool-processor"
-version = "0.26.0"
+version = "0.26.1"
 description = "Async-native framework for registering, discovering, and executing tools referenced in LLM responses"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Short-term guard: the chuk-mcp 0.10 line is the Rust-backed build that depends on the not-yet-published `chuk-mcp-rs`. Without a cap, a 0.10 release would be auto-resolved by `chuk-mcp>=0.9` and break installs — including transitively for mcp-cli, which pulls chuk-tool-processor.

Upper bound still allows 0.9.x patch/security releases. Lift once chuk-mcp-rs (and chuk-mcp 0.10) are published and validated.

Needs a 0.26.1 patch release to protect consumers on PyPI.